### PR TITLE
Add logic to uncompress pipeline intermediate if needed

### DIFF
--- a/downloader/artifact_downloader.go
+++ b/downloader/artifact_downloader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/filedownloader"
 	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-steplib/bitrise-step-pull-intermediate-files/api"
 )
@@ -124,7 +125,12 @@ func (ad *ConcurrentArtifactDownloader) downloadFile(targetDir, fileName, downlo
 }
 
 func (ad *ConcurrentArtifactDownloader) downloadAndExtractZipArchive(targetDir, fileName, downloadURL string) (string, error) {
-	fileFullPath, err := ad.downloadFile(targetDir, fileName, downloadURL)
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("pull-intermediate-files")
+	if err != nil {
+		return "", err
+	}
+
+	fileFullPath, err := ad.downloadFile(tmpDir, fileName, downloadURL)
 	if err != nil {
 		return "", err
 	}
@@ -163,7 +169,7 @@ func (ad *ConcurrentArtifactDownloader) downloadAndExtractTarArchive(targetDir, 
 	}
 
 	if err := resp.Body.Close(); err != nil {
-		log.Warnf("Failed to close response body: %s", err)
+		ad.Logger.Warnf("Failed to close response body: %s", err)
 	}
 
 	return dirPath, nil

--- a/downloader/artifact_downloader.go
+++ b/downloader/artifact_downloader.go
@@ -177,16 +177,7 @@ func (ad *ConcurrentArtifactDownloader) downloadAndExtractTarArchive(targetDir, 
 
 func (ad *ConcurrentArtifactDownloader) extractZipArchive(archivePath string, targetDir string) error {
 	cmd := ad.CommandFactory.Create("unzip", []string{archivePath}, &command.Opts{Dir: targetDir})
-
-	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cmd.PrintableCommandArgs(), errors.New(out))
-		}
-		return fmt.Errorf("%s failed: %w", cmd.PrintableCommandArgs(), err)
-	}
-
-	return nil
+	return ad.runExtractionCommand(cmd)
 }
 
 func (ad *ConcurrentArtifactDownloader) extractTarArchive(r io.Reader, targetDir string) error {
@@ -198,7 +189,10 @@ func (ad *ConcurrentArtifactDownloader) extractTarArchive(r io.Reader, targetDir
 		Stdin: r,
 		Dir:   targetDir,
 	})
+	return ad.runExtractionCommand(cmd)
+}
 
+func (ad *ConcurrentArtifactDownloader) runExtractionCommand(cmd command.Command) error {
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/downloader/artifact_downloader.go
+++ b/downloader/artifact_downloader.go
@@ -129,8 +129,6 @@ func (ad *ConcurrentArtifactDownloader) downloadAndExtractZipArchive(targetDir, 
 		return "", err
 	}
 
-	fmt.Println("targetDir: ", targetDir)
-
 	dirName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
 	dirPath := filepath.Join(targetDir, dirName)
 
@@ -152,8 +150,6 @@ func (ad *ConcurrentArtifactDownloader) downloadAndExtractTarArchive(targetDir, 
 	if err != nil {
 		return "", err
 	}
-
-	fmt.Println("targetDir: ", targetDir)
 
 	dirName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
 	dirPath := filepath.Join(targetDir, dirName)

--- a/downloader/artifact_downloader_test.go
+++ b/downloader/artifact_downloader_test.go
@@ -111,7 +111,7 @@ func Test_DownloadAndSaveDirectoryArtifacts(t *testing.T) {
 	cmd.On("Run").Return(nil).Once()
 
 	cmdFactory := new(mocks.Factory)
-	cmdFactory.On("Create", "tar", []string{"-x", "-f", "-"}, mock.Anything).Return(cmd).Once()
+	cmdFactory.On("Create", "unzip", []string{}, mock.Anything).Return(cmd).Once()
 
 	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory)
 

--- a/downloader/artifact_downloader_test.go
+++ b/downloader/artifact_downloader_test.go
@@ -108,10 +108,10 @@ func Test_DownloadAndSaveDirectoryArtifacts(t *testing.T) {
 	}
 
 	cmd := new(mocks.Command)
-	cmd.On("Run").Return(nil).Once()
+	cmd.On("RunAndReturnTrimmedCombinedOutput").Return("", nil).Once()
 
 	cmdFactory := new(mocks.Factory)
-	cmdFactory.On("Create", "unzip", []string{}, mock.Anything).Return(cmd).Once()
+	cmdFactory.On("Create", "unzip", mock.Anything, mock.Anything).Return(cmd).Once()
 
 	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory)
 

--- a/downloader/artifact_downloader_test.go
+++ b/downloader/artifact_downloader_test.go
@@ -81,7 +81,7 @@ func Test_DownloadAndSaveArtifacts_DownloadFails(t *testing.T) {
 	_ = os.RemoveAll(targetDir)
 }
 
-func Test_DownloadAndSaveDirectoryArtifacts(t *testing.T) {
+func Test_DownloadAndSaveZipDirectoryArtifacts(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, "dummy data")
 	}))
@@ -112,6 +112,50 @@ func Test_DownloadAndSaveDirectoryArtifacts(t *testing.T) {
 
 	cmdFactory := new(mocks.Factory)
 	cmdFactory.On("Create", "unzip", mock.Anything, mock.Anything).Return(cmd).Once()
+
+	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory)
+
+	downloadResults, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
+
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, expectedDownloadResults, downloadResults)
+	cmd.AssertExpectations(t)
+	cmdFactory.AssertExpectations(t)
+
+	_ = os.RemoveAll(targetDir)
+}
+
+func Test_DownloadAndSaveTarDirectoryArtifacts(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "dummy data")
+	}))
+	defer svr.Close()
+
+	targetDir, err := getDownloadDir(relativeDownloadPath)
+	assert.NoError(t, err)
+
+	downloadURL := fmt.Sprintf(svr.URL + "/1.tar")
+	artifacts := []api.ArtifactResponseItemModel{
+		{
+			DownloadURL: downloadURL,
+			Title:       "1.tar",
+			IntermediateFileInfo: api.IntermediateFileInfo{
+				IsDir: true,
+			},
+		},
+	}
+	expectedDownloadResults := []ArtifactDownloadResult{
+		{
+			DownloadPath: targetDir + "/1",
+			DownloadURL:  downloadURL,
+		},
+	}
+
+	cmd := new(mocks.Command)
+	cmd.On("RunAndReturnTrimmedCombinedOutput").Return("", nil).Once()
+
+	cmdFactory := new(mocks.Factory)
+	cmdFactory.On("Create", "tar", mock.Anything, mock.Anything).Return(cmd).Once()
 
 	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory)
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -6,54 +6,51 @@ app:
   # Shared envs for every test workflow
   - BITRISEIO_FINISHED_STAGES: |-
         [{
-            "id": "996e8a18-947e-4bed-940d-c65e8439245f",
-            "name": "stage-1-new",
+            "id": "b3562352-8be1-404b-bd80-464e8528dc7b",
+            "name": "stage-1",
             "workflows": [{
                 "credit_cost": 2,
-                "external_id": "2ffa98aa-92d8-456f-9ba4-4d1d6548cfb3",
-                "finished_at": "2022-11-14T06:28:15Z",
-                "id": "eab6d91a-b3ff-4744-9f2a-ac15b8acf3b2",
+                "external_id": "65aad896-2c52-4947-8781-26c1210043ac",
+                "finished_at": "2022-11-25T08:40:09Z",
+                "id": "076fb94d-6f1d-44f2-9e92-cbc9c73812a3",
                 "name": "placeholder",
-                "started_at": "2022-11-14T06:28:14Z",
+                "started_at": "2022-11-25T08:40:07Z",
                 "status": "succeeded"
-            },
-            {
+            }, {
                 "credit_cost": 2,
-                "external_id": "08c8cc72-e98d-47de-92a5-09b6bd7d55df",
-                "finished_at": "2022-11-14T06:28:28Z",
-                "id": "095f534e-d98c-41a8-9d0e-6959380ed039",
-                "name": "textfile_generator-new",
-                "started_at": "2022-11-14T06:28:14Z",
+                "external_id": "646b36c3-324b-4f08-a607-a491ecf041e9",
+                "finished_at": "2022-11-25T08:40:17Z",
+                "id": "70642fc8-cc2c-4809-8a95-f10a893625f8",
+                "name": "textfile_generator",
+                "started_at": "2022-11-25T08:40:06Z",
                 "status": "succeeded"
             }]
         }, {
-            "id": "3b5136b6-92c6-4576-aedc-9e21cba8432c",
-            "name": "stage-2-new",
+            "id": "d11e8056-6d00-4ad7-9cfe-a4cd304e2800",
+            "name": "stage-2",
             "workflows": [{
                 "credit_cost": null,
-                "external_id": "00c49d06-d1d8-4ee9-a0ce-ee340228740d",
-                "finished_at": "2022-11-14T06:29:14Z",
-                "id": "48574051-24f6-4571-9aaa-d1589f7cece4",
-                "name": "deployer-new",
-                "started_at": "2022-11-14T06:28:58Z",
+                "external_id": "71fbb643-8237-4d55-abf8-2eef1553e0c9",
+                "finished_at": "2022-11-25T08:40:38Z",
+                "id": "5c36785b-ccba-4c87-a96d-9162d22149fa",
+                "name": "deployer",
+                "started_at": "2022-11-25T08:40:20Z",
                 "status": "succeeded"
-            },
-            {
+            }, {
                 "credit_cost": 2,
-                "external_id": "bb1d9f29-e85f-4ace-a4a7-592901eb9f61",
-                "finished_at": "2022-11-14T06:28:43Z",
-                "id": "b7cff818-bbbb-4372-9d0c-f800660408e8",
-                "name": "textfile_generator-new",
-                "started_at": "2022-11-14T06:28:30Z",
+                "external_id": "e0c99fa6-ffe1-4b5d-8b74-498c0b791c6e",
+                "finished_at": "2022-11-25T08:40:36Z",
+                "id": "290f54ba-d8d5-417e-9a9b-b723a3c5132e",
+                "name": "zip_archive_generator",
+                "started_at": "2022-11-25T08:40:22Z",
                 "status": "succeeded"
-            },
-            {
-                "credit_cost": 2,
-                "external_id": "f2f498a1-c091-405c-9844-294938ba6339",
-                "finished_at": "2022-11-14T06:28:43Z",
-                "id": "74dd46a3-dc0b-43f2-9cb5-a3d4ffec0e83",
-                "name": "archive_generator",
-                "started_at": "2022-11-14T06:28:30Z",
+            }, {
+                "credit_cost": null,
+                "external_id": "db1be3dd-167c-440c-b87e-93e2f0cee445",
+                "finished_at": "2022-11-25T08:40:37Z",
+                "id": "c7d9adab-9378-49b5-b370-2358d490be30",
+                "name": "tar_archive_generator",
+                "started_at": "2022-11-25T08:40:22Z",
                 "status": "succeeded"
             }]
         }]
@@ -61,6 +58,73 @@ app:
   - BITRISE_AUTH_SERVICE_ARTIFACT_PULL_CLIENT_SECRET: $BITRISE_AUTH_SERVICE_ARTIFACT_PULL_CLIENT_SECRET
 
 workflows:
+  test_download_tar_archive:
+    before_run:
+    - _setup
+    - _cleanup
+    steps:
+    - path::./:
+        title: Execute step
+        inputs:
+        - verbose: true
+        - artifact_sources: stage-2\.tar_archive_generator
+        - bitrise_api_base_url: https://api.bitrise.io
+    - git::https://github.com/bitrise-steplib/bitrise-step-check-step-outputs.git@main:
+        title: Validate downloaded artifacts
+        is_always_run: true
+        inputs:
+        - files: |-
+            ARCHIVE_LAYOUT
+        - dirs: |-
+            ARCHIVE_TAR
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -ex
+            cd $ARCHIVE_TAR
+            actual=$(tree -L 1 .)
+            expected=$(cat $ARCHIVE_LAYOUT)
+            if [ "$actual" != "$expected" ]; then
+              echo "actual:\n$actual"
+              echo
+              echo "expected:\n$expected"
+              exit 1
+            fi
+
+  test_download_zip_archive:
+    before_run:
+    - _setup
+    - _cleanup
+    steps:
+    - path::./:
+        title: Execute step
+        inputs:
+        - verbose: true
+        - artifact_sources: stage-2\.zip_archive_generator
+        - bitrise_api_base_url: https://api.bitrise.io
+    - git::https://github.com/bitrise-steplib/bitrise-step-check-step-outputs.git@main:
+        title: Validate downloaded artifacts
+        is_always_run: true
+        inputs:
+        - files: |-
+            ARCHIVE_LAYOUT
+        - dirs: |-
+            ARCHIVE_ZIP
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -ex
+            cd $ARCHIVE_ZIP
+            actual=$(tree -L 1 .)
+            expected=$(cat $ARCHIVE_LAYOUT)
+            if [ "$actual" != "$expected" ]; then
+              echo "actual:\n$actual"
+              echo
+              echo "expected:\n$expected"
+              exit 1
+            fi
 
   test_download_all_artifacts_of_build:
     before_run:
@@ -94,7 +158,7 @@ workflows:
         title: Execute step
         inputs:
         - verbose: true
-        - artifact_sources: stage-1-new\..*
+        - artifact_sources: stage-1\..*
         - bitrise_api_base_url: https://api.bitrise.io
     - git::https://github.com/bitrise-steplib/bitrise-step-check-step-outputs.git@main:
         title: Validate downloaded artifacts
@@ -130,7 +194,7 @@ workflows:
                 --data "client_secret=$BITRISE_AUTH_SERVICE_ARTIFACT_PULL_CLIENT_SECRET" \
                 --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
                 --data "scope=build_artifact:read build:read app:read" \
-                --data "claim_token=ewogICJidWlsZF9pZHMiOiBbCiAgICAiMmZmYTk4YWEtOTJkOC00NTZmLTliYTQtNGQxZDY1NDhjZmIzIiwKICAgICIwOGM4Y2M3Mi1lOThkLTQ3ZGUtOTJhNS0wOWI2YmQ3ZDU1ZGYiLAogICAgIjAwYzQ5ZDA2LWQxZDgtNGVlOS1hMGNlLWVlMzQwMjI4NzQwZCIsCiAgICAiYmIxZDlmMjktZTg1Zi00YWNlLWE0YTctNTkyOTAxZWI5ZjYxIiwKICAgICJmMmY0OThhMS1jMDkxLTQwNWMtOTg0NC0yOTQ5MzhiYTYzMzkiCiAgXSwKICAicGlwZWxpbmVfaWQiOiBbCiAgICAiMjg3ZWU1OGQtMmI3Ny00MDJhLWFhMWMtODM1ZGNjMGNlOTcwIgogIF0KfQ==" \
+                --data "claim_token=ewogICJidWlsZF9pZHMiOiBbCiAgICAiNjVhYWQ4OTYtMmM1Mi00OTQ3LTg3ODEtMjZjMTIxMDA0M2FjIiwKICAgICI2NDZiMzZjMy0zMjRiLTRmMDgtYTYwNy1hNDkxZWNmMDQxZTkiLAogICAgIjcxZmJiNjQzLTgyMzctNGQ1NS1hYmY4LTJlZWYxNTUzZTBjOSIsCiAgICAiZTBjOTlmYTYtZmZlMS00YjVkLThiNzQtNDk4YzBiNzkxYzZlIiwKICAgICJkYjFiZTNkZC0xNjdjLTQ0MGMtYjg3ZS05M2UyZjBjZWU0NDUiCiAgXSwKICAicGlwZWxpbmVfaWQiOiBbCiAgICAiMTZlZTg4MGQtYjBlNS00ZTAxLWE4NzYtNDMzOTk1YWQ2N2MxIgogIF0KfQo=" \
                 --data "claim_token_format=urn:ietf:params:oauth:token-type:jwt" \
                 --data "audience=bitrise-api")
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -6,54 +6,54 @@ app:
   # Shared envs for every test workflow
   - BITRISEIO_FINISHED_STAGES: |-
         [{
-            "id": "730fde2f-669d-4ed3-9d0c-49fb1e62cbb4",
+            "id": "996e8a18-947e-4bed-940d-c65e8439245f",
             "name": "stage-1-new",
             "workflows": [{
                 "credit_cost": 2,
-                "external_id": "0f8ec208-6496-470c-9c5b-dacd8bdd8b01",
-                "finished_at": "2022-10-12T23:27:19Z",
-                "id": "3dceca00-535e-4bf5-bc40-48815ca79ed9",
+                "external_id": "2ffa98aa-92d8-456f-9ba4-4d1d6548cfb3",
+                "finished_at": "2022-11-14T06:28:15Z",
+                "id": "eab6d91a-b3ff-4744-9f2a-ac15b8acf3b2",
                 "name": "placeholder",
-                "started_at": "2022-10-12T23:27:18Z",
+                "started_at": "2022-11-14T06:28:14Z",
                 "status": "succeeded"
             },
             {
                 "credit_cost": 2,
-                "external_id": "ba1c7066-a7a1-43cf-87ba-34f104e4b846",
-                "finished_at": "2022-10-12T23:27:29Z",
-                "id": "3590eaf3-a1da-44cd-b63d-69fa0a8e8615",
+                "external_id": "08c8cc72-e98d-47de-92a5-09b6bd7d55df",
+                "finished_at": "2022-11-14T06:28:28Z",
+                "id": "095f534e-d98c-41a8-9d0e-6959380ed039",
                 "name": "textfile_generator-new",
-                "started_at": "2022-10-12T23:27:19Z",
+                "started_at": "2022-11-14T06:28:14Z",
                 "status": "succeeded"
             }]
         }, {
-            "id": "747fed17-bc9f-4dff-ac8a-974f8f80e55c",
+            "id": "3b5136b6-92c6-4576-aedc-9e21cba8432c",
             "name": "stage-2-new",
             "workflows": [{
                 "credit_cost": null,
-                "external_id": "87e08554-a47a-4690-9a19-5525a00d2276",
-                "finished_at": "2022-10-12T23:27:52Z",
-                "id": "7b079fd0-c41f-4ab4-bc3c-0e023d800858",
+                "external_id": "00c49d06-d1d8-4ee9-a0ce-ee340228740d",
+                "finished_at": "2022-11-14T06:29:14Z",
+                "id": "48574051-24f6-4571-9aaa-d1589f7cece4",
                 "name": "deployer-new",
-                "started_at": "2022-10-12T23:27:34Z",
+                "started_at": "2022-11-14T06:28:58Z",
                 "status": "succeeded"
             },
             {
                 "credit_cost": 2,
-                "external_id": "0d4f0389-c985-4f74-85cc-3ad5a6ef46b9",
-                "finished_at": "2022-10-12T23:27:47Z",
-                "id": "1bb2b686-2096-4308-9851-b6a1a846fcda",
+                "external_id": "bb1d9f29-e85f-4ace-a4a7-592901eb9f61",
+                "finished_at": "2022-11-14T06:28:43Z",
+                "id": "b7cff818-bbbb-4372-9d0c-f800660408e8",
                 "name": "textfile_generator-new",
-                "started_at": "2022-10-12T23:27:37Z",
+                "started_at": "2022-11-14T06:28:30Z",
                 "status": "succeeded"
             },
             {
                 "credit_cost": 2,
-                "external_id": "4378c148-77f0-4b2c-ab25-054664569b16",
-                "finished_at": "2022-10-12T23:27:42Z",
-                "id": "5c991fc2-c009-4838-88b9-172e19fc6b98",
+                "external_id": "f2f498a1-c091-405c-9844-294938ba6339",
+                "finished_at": "2022-11-14T06:28:43Z",
+                "id": "74dd46a3-dc0b-43f2-9cb5-a3d4ffec0e83",
                 "name": "archive_generator",
-                "started_at": "2022-10-12T23:27:32Z",
+                "started_at": "2022-11-14T06:28:30Z",
                 "status": "succeeded"
             }]
         }]
@@ -83,7 +83,7 @@ workflows:
             TEST_JSON
             TEXT_FILE_TXT
         - dirs: |-
-            ARCHIVE_TAR
+            ARCHIVE_ZIP
 
   test_download_specific_stage_artifacts:
     before_run:
@@ -130,7 +130,7 @@ workflows:
                 --data "client_secret=$BITRISE_AUTH_SERVICE_ARTIFACT_PULL_CLIENT_SECRET" \
                 --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
                 --data "scope=build_artifact:read build:read app:read" \
-                --data "claim_token=ewogICJidWlsZF9pZHMiOiBbCiAgICAiMGY4ZWMyMDgtNjQ5Ni00NzBjLTljNWItZGFjZDhiZGQ4YjAxIiwKICAgICJiYTFjNzA2Ni1hN2ExLTQzY2YtODdiYS0zNGYxMDRlNGI4NDYiLAogICAgIjg3ZTA4NTU0LWE0N2EtNDY5MC05YTE5LTU1MjVhMDBkMjI3NiIsCiAgICAiMGQ0ZjAzODktYzk4NS00Zjc0LTg1Y2MtM2FkNWE2ZWY0NmI5IiwKICAgICI0Mzc4YzE0OC03N2YwLTRiMmMtYWIyNS0wNTQ2NjQ1NjliMTYiCiAgXSwKICAicGlwZWxpbmVfaWQiOiBbCiAgICAiNWI5MTY1OTAtM2U4Zi00MTE5LTk1M2EtN2IzYzFmNmU0NGQ3IgogIF0KfQ==" \
+                --data "claim_token=ewogICJidWlsZF9pZHMiOiBbCiAgICAiMmZmYTk4YWEtOTJkOC00NTZmLTliYTQtNGQxZDY1NDhjZmIzIiwKICAgICIwOGM4Y2M3Mi1lOThkLTQ3ZGUtOTJhNS0wOWI2YmQ3ZDU1ZGYiLAogICAgIjAwYzQ5ZDA2LWQxZDgtNGVlOS1hMGNlLWVlMzQwMjI4NzQwZCIsCiAgICAiYmIxZDlmMjktZTg1Zi00YWNlLWE0YTctNTkyOTAxZWI5ZjYxIiwKICAgICJmMmY0OThhMS1jMDkxLTQwNWMtOTg0NC0yOTQ5MzhiYTYzMzkiCiAgXSwKICAicGlwZWxpbmVfaWQiOiBbCiAgICAiMjg3ZWU1OGQtMmI3Ny00MDJhLWFhMWMtODM1ZGNjMGNlOTcwIgogIF0KfQ==" \
                 --data "claim_token_format=urn:ietf:params:oauth:token-type:jwt" \
                 --data "audience=bitrise-api")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

We discussed that using `zip` for build artifacts and `tar` for pipeline intermediates is not ideal moving forward due to having to maintain both tools across stacks, so this PR adds support for extracting `zip` archives.

For compatibility with the deploy-to-bitrise-io step version 2.1.3, support for `tar` archives is kept.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->


### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

Also considered just compressing pipeline intermediates with the previous changes to `tar`.

### Decisions

<!-- Please list decisions that were made for this change. -->

The plan moving forward is to consolidate and use `zip` across the board instead of making additional changes to accommodate `tar` in order to avoid having to maintain both tools across stacks. `zip` also gives the benefit of compressing the archive by default.
