### PR TITLE
Improve artifact list error handling

### DIFF
--- a/api/artifact_lister.go
+++ b/api/artifact_lister.go
@@ -77,7 +77,7 @@ func (lister ArtifactLister) ListIntermediateFileDetails(appSlug string, buildSl
 	for i := 1; i <= len(buildSlugs); i++ {
 		res := <-listResults
 		if res.err != nil {
-			lister.logger.Warnf("Failed to list artifacts for build %s: %w", res.buildSlug, res.err)
+			lister.logger.Warnf("Failed to list artifacts for build %s: %s", res.buildSlug, res.err)
 			failedBuildSlugs = append(failedBuildSlugs, res.buildSlug)
 		} else {
 			artifacts = append(artifacts, res.artifacts...)

--- a/api/artifact_lister.go
+++ b/api/artifact_lister.go
@@ -95,8 +95,8 @@ func (lister ArtifactLister) ListIntermediateFileDetails(appSlug string, buildSl
 func (lister ArtifactLister) listArtifactsWorker(appSlug string, buildSlugs chan string, results chan listArtifactsResult) {
 	for buildSlug := range buildSlugs {
 		if buildSlug == "" {
-			lister.logger.Warnf("Build slug is empty, skipping...")
-			continue
+			lister.logger.Warnf("Build slug is empty")
+			// Continue because the results channel is expected to have len(buildSlugs) items. Error will be handled later.
 		}
 
 		lister.logger.Debugf("Listing artifacts for build: https://app.bitrise.io/build/%v", buildSlug)

--- a/api/artifact_lister.go
+++ b/api/artifact_lister.go
@@ -77,6 +77,7 @@ func (lister ArtifactLister) ListIntermediateFileDetails(appSlug string, buildSl
 	for i := 1; i <= len(buildSlugs); i++ {
 		res := <-listResults
 		if res.err != nil {
+			lister.logger.Warnf("Failed to list artifacts for build %s: %w", res.buildSlug, res.err)
 			failedBuildSlugs = append(failedBuildSlugs, res.buildSlug)
 		} else {
 			artifacts = append(artifacts, res.artifacts...)
@@ -93,6 +94,11 @@ func (lister ArtifactLister) ListIntermediateFileDetails(appSlug string, buildSl
 // listArtifactsWorker gets details of all artifacts of a particular build using the Bitrise API
 func (lister ArtifactLister) listArtifactsWorker(appSlug string, buildSlugs chan string, results chan listArtifactsResult) {
 	for buildSlug := range buildSlugs {
+		if buildSlug == "" {
+			lister.logger.Warnf("Build slug is empty, skipping...")
+			continue
+		}
+
 		lister.logger.Debugf("Listing artifacts for build: https://app.bitrise.io/build/%v", buildSlug)
 		artifactListItems, err := lister.apiClient.ListBuildArtifacts(appSlug, buildSlug)
 		if err != nil {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Sometimes the step fails with this meaningless error message:

```
Getting the list of artifacts of 1 builds
Run: failed to list artifacts: failed to get artifact download links for build(s): 
```

### Changes

- Print the real error to the build logs, not just the build ID it's related to
- Add an extra validation for empty build IDs. Based on the error message, somehow the build ID ended up empty.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
