### PR TITLE
Skip step execution if API token is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Do not forget to escape the special characters when using a regex pattern.
 | `app_slug` | The slug that uniquely identifies your app on bitrise.io. It’s part of the app URL, too. | required | `$BITRISE_APP_SLUG` |
 | `finished_stage` | This is a JSON representation of the finished stages for which the step can download build artifacts. | required | `$BITRISEIO_FINISHED_STAGES` |
 | `bitrise_api_base_url` | The base URL of the Bitrise API used to process the download requests. | required | `https://api.bitrise.io` |
-| `bitrise_api_access_token` | The OAuth access token that authorizes to call the Bitrise API. | required, sensitive | `$BITRISEIO_ARTIFACT_PULL_TOKEN` |
+| `bitrise_api_access_token` | The OAuth access token that authorizes to call the Bitrise API. | sensitive | `$BITRISEIO_ARTIFACT_PULL_TOKEN` |
 </details>
 
 <details>

--- a/step.yml
+++ b/step.yml
@@ -98,6 +98,6 @@ inputs:
   opts:
     title: Access token to call the Bitrise API
     summary: The OAuth access token that authorizes to call the Bitrise API.
-    is_required: true
+    is_required: false
     is_sensitive: true
     is_dont_change_value: true

--- a/step/step.go
+++ b/step/step.go
@@ -3,6 +3,7 @@ package step
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -25,7 +26,7 @@ type Input struct {
 	AppSlug               string          `env:"app_slug,required"`
 	FinishedStages        string          `env:"finished_stage,required"`
 	BitriseAPIBaseURL     string          `env:"bitrise_api_base_url,required"`
-	BitriseAPIAccessToken stepconf.Secret `env:"bitrise_api_access_token,required"`
+	BitriseAPIAccessToken stepconf.Secret `env:"bitrise_api_access_token"`
 }
 
 type Config struct {
@@ -60,6 +61,12 @@ func (d IntermediateFileDownloader) ProcessConfig() (Config, error) {
 
 	stepconf.Print(input)
 	d.logger.EnableDebugLog(input.Verbose)
+
+	if strings.TrimSpace(string(input.BitriseAPIAccessToken)) == "" {
+		d.logger.Warnf("Bitrise API token is unavailable, skipping step.")
+		d.logger.Printf("Hint: maybe this build is running in the first stage of a pipeline? If so, pulling intermediate files is not possible.")
+		os.Exit(0)
+	}
 
 	finishedStages := input.FinishedStages
 	var finishedStagesModel model.FinishedStages

--- a/step/step.go
+++ b/step/step.go
@@ -2,8 +2,8 @@ package step
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -19,6 +19,8 @@ import (
 )
 
 const downloadDirPrefix = "_artifact_pull"
+
+var ErrMissingAccessToken = errors.New("missing Bitrise API access token")
 
 type Input struct {
 	ArtifactSources       string          `env:"artifact_sources,required"`
@@ -63,9 +65,7 @@ func (d IntermediateFileDownloader) ProcessConfig() (Config, error) {
 	d.logger.EnableDebugLog(input.Verbose)
 
 	if strings.TrimSpace(string(input.BitriseAPIAccessToken)) == "" {
-		d.logger.Warnf("Bitrise API token is unavailable, skipping step.")
-		d.logger.Printf("Hint: maybe this build is running in the first stage of a pipeline? If so, pulling intermediate files is not possible.")
-		os.Exit(0)
+		return Config{}, ErrMissingAccessToken
 	}
 
 	finishedStages := input.FinishedStages


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

This step is not supposed to work in the first stage of a pipeline (there is nothing to pull reliably), and the token is not even generated for builds running in the first stage.

### Changes

Skip execution if the token is not available, as well as print a hint for why the token is not available.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
