### PR TITLE
Use cache specific download settings

### DIFF
--- a/downloader/artifact_downloader.go
+++ b/downloader/artifact_downloader.go
@@ -145,6 +145,10 @@ func (ad *ConcurrentArtifactDownloader) downloadFile(targetDir, fileName, downlo
 		if strings.Contains(errorMessage, "Response status code is not ok: 416") || strings.Contains(errorMessage, "unexpected EOF") {
 			ad.Logger.Warnf("Multi threaded download failed, switching to single threaded download")
 
+			cancel()
+
+			ctx, cancel = context.WithTimeout(context.Background(), ad.Timeout)
+
 			start = time.Now()
 
 			downloader := filedownloader.NewWithContext(ctx, retryhttp.NewClient(ad.Logger).StandardClient())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The got downloader received the same setup block as what our cache steps use. The values are what the current returns. 

The single threaded downloader also starts with a new timeout value.