### PR TITLE
Add ziputil v2 (pure-Go) ZIP extraction behind a feature flag

### DIFF
--- a/downloader/artifact_downloader.go
+++ b/downloader/artifact_downloader.go
@@ -25,7 +25,9 @@ import (
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
+	pathutilv2 "github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-io/go-utils/v2/retryhttp"
+	"github.com/bitrise-io/go-utils/v2/ziputil"
 	"github.com/bitrise-io/got"
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -58,13 +60,17 @@ type ConcurrentArtifactDownloader struct {
 	Timeout        time.Duration
 	Logger         log.Logger
 	CommandFactory command.Factory
+	// UseZipV2 selects the pure-Go ziputil.UnZip extractor over the legacy `unzip` CLI.
+	// Toggled by the BITRISE_STEP_PULL_ARTIFACT_USE_ZIP_V2 env var.
+	UseZipV2 bool
 }
 
-func NewConcurrentArtifactDownloader(timeout time.Duration, logger log.Logger, commandFactory command.Factory) *ConcurrentArtifactDownloader {
+func NewConcurrentArtifactDownloader(timeout time.Duration, logger log.Logger, commandFactory command.Factory, useZipV2 bool) *ConcurrentArtifactDownloader {
 	return &ConcurrentArtifactDownloader{
 		Timeout:        timeout,
 		Logger:         logger,
 		CommandFactory: commandFactory,
+		UseZipV2:       useZipV2,
 	}
 }
 
@@ -276,6 +282,12 @@ func (ad *ConcurrentArtifactDownloader) downloadAndExtractTarArchive(targetDir, 
 }
 
 func (ad *ConcurrentArtifactDownloader) extractZipArchive(archivePath string, targetDir string) error {
+	if ad.UseZipV2 {
+		ad.Logger.Debugf("Extracting %s with ziputil v2 (pure Go)", archivePath)
+		zipManager := ziputil.NewZipManager(pathutilv2.NewPathChecker())
+		return zipManager.UnZip(archivePath, targetDir)
+	}
+
 	cmd := ad.CommandFactory.Create("unzip", []string{"-o", archivePath}, &command.Opts{Dir: targetDir})
 	return ad.runExtractionCommand(cmd)
 }

--- a/downloader/artifact_downloader_test.go
+++ b/downloader/artifact_downloader_test.go
@@ -1,10 +1,13 @@
 package downloader
 
 import (
+	"archive/zip"
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"testing/fstest"
@@ -51,7 +54,7 @@ func Test_DownloadAndSaveArtifacts(t *testing.T) {
 		})
 	}
 
-	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), nil)
+	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), nil, false)
 
 	downloadResults, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
 	assert.NoError(t, err)
@@ -103,7 +106,7 @@ func Test_DownloadAndSaveArtifacts_DownloadFails(t *testing.T) {
 		api.ArtifactResponseItemModel{DownloadURL: downloadURL, Title: "1.txt"})
 
 	// TODO: mock command factory
-	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), nil)
+	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), nil, false)
 
 	result, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
 
@@ -134,7 +137,7 @@ func Test_DownloadAndSaveArtifacts_RetriesFailingDownload(t *testing.T) {
 		{DownloadURL: svr.URL + "/1.txt", Title: "1.txt"},
 	}
 
-	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Second, log.NewLogger(), nil)
+	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Second, log.NewLogger(), nil, false)
 	_, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
 
 	assert.NoError(t, err)
@@ -166,7 +169,7 @@ func Test_DownloadAndSaveZipDirectoryArtifacts(t *testing.T) {
 	cmdFactory := new(mocks.Factory)
 	cmdFactory.On("Create", "unzip", mock.Anything, mock.Anything).Return(cmd).Once()
 
-	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory)
+	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory, false)
 
 	downloadResults, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
 	assert.NoError(t, err)
@@ -186,6 +189,56 @@ func Test_DownloadAndSaveZipDirectoryArtifacts(t *testing.T) {
 	unzipCmdArguments := cmdFactory.Calls[0].Arguments[1].([]string)
 	assert.Len(t, unzipCmdArguments, 2)
 	assert.Equal(t, "-o", unzipCmdArguments[0])
+}
+
+func Test_DownloadAndSaveZipDirectoryArtifacts_ZipV2(t *testing.T) {
+	// Build a real zip archive so the pure-Go ziputil.UnZip has valid input to extract.
+	var archive bytes.Buffer
+	zw := zip.NewWriter(&archive)
+	w, err := zw.Create("hello.txt")
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("hello world"))
+	assert.NoError(t, err)
+	assert.NoError(t, zw.Close())
+	zipBytes := archive.Bytes()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(zipBytes)
+	}))
+	defer svr.Close()
+
+	targetDir := getDownloadDir(t)
+
+	downloadURL := fmt.Sprintf("%s/1.zip", svr.URL)
+	artifacts := []api.ArtifactResponseItemModel{
+		{
+			DownloadURL: downloadURL,
+			Title:       "1.zip",
+			IntermediateFileInfo: api.IntermediateFileInfo{
+				IsDir: true,
+			},
+		},
+	}
+
+	// A command factory with no expectations: invoking the `unzip` CLI here would fail the test,
+	// proving the v2 path bypasses it entirely.
+	cmdFactory := new(mocks.Factory)
+
+	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory, true)
+
+	downloadResults, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(downloadResults))
+	assert.NoError(t, downloadResults[0].DownloadError)
+	assert.Equal(t, filepath.Join(targetDir, "1"), downloadResults[0].DownloadPath)
+
+	extracted, err := os.ReadFile(filepath.Join(targetDir, "1", "hello.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", string(extracted))
+
+	// The pure-Go extractor must not have shelled out to the `unzip` CLI.
+	assert.Len(t, cmdFactory.Calls, 0)
 }
 
 func Test_DownloadAndSaveTarDirectoryArtifacts(t *testing.T) {
@@ -213,7 +266,7 @@ func Test_DownloadAndSaveTarDirectoryArtifacts(t *testing.T) {
 	cmdFactory := new(mocks.Factory)
 	cmdFactory.On("Create", "tar", mock.Anything, mock.Anything).Return(cmd).Once()
 
-	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory)
+	artifactDownloader := NewConcurrentArtifactDownloader(5*time.Minute, log.NewLogger(), cmdFactory, false)
 
 	downloadResults, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
 	assert.NoError(t, err)

--- a/e2etest/bitrise.yml
+++ b/e2etest/bitrise.yml
@@ -1,6 +1,10 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: other
+app:
+  envs:
+  # Exercise the pure-Go ziputil v2 extraction path in the e2e tests.
+  - BITRISE_STEP_PULL_ARTIFACT_USE_ZIP_V2: "true"
 workflows:
   test_all:
     after_run:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.34
 	github.com/bitrise-io/go-utils v1.0.13
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36.0.20260612135825-fa80291d0871
 	github.com/bitrise-io/got v0.0.0-20250613112826-9af8c0e04db5
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.34 h1:X/iq5GttYmdOJG74kXZ80tG
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.34/go.mod h1:EiSwIs7eqfddVHxEvCIdQdvc7+/HeIy15fYy486n/vE=
 github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=
 github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23 h1:Dfh4nyZPuEtilBisidejqxBrkx9cWvbOUrpq8VEION0=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23/go.mod h1:3XUplo0dOWc3DqT2XA2SeHToDSg7+j1y1HTHibT2H68=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36.0.20260612135825-fa80291d0871 h1:pYOZwG/04O9KIE+8/wbqQ4SXwLWm/6zFU+vV2BL9Ag4=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36.0.20260612135825-fa80291d0871/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/got v0.0.0-20250613112826-9af8c0e04db5 h1:VOjnj30ShP7XPBW98L59pv+DZ1vnxV3xM9yDr/BWUCo=
 github.com/bitrise-io/got v0.0.0-20250613112826-9af8c0e04db5/go.mod h1:uBBISwY9ylo62hC1MRHqGxH+VJGHwXR1VJ17QApnG14=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/step/step.go
+++ b/step/step.go
@@ -128,7 +128,8 @@ func (d IntermediateFileDownloader) Run(cfg Config) (Result, error) {
 		return Result{}, fmt.Errorf("failed to create artifact download directory: %w", err)
 	}
 
-	artifactDownloader := downloader.NewConcurrentArtifactDownloader(5*time.Minute, d.logger, d.cmdFactory)
+	useZipV2 := d.envRepository.Get("BITRISE_STEP_PULL_ARTIFACT_USE_ZIP_V2") == "true"
+	artifactDownloader := downloader.NewConcurrentArtifactDownloader(5*time.Minute, d.logger, d.cmdFactory, useZipV2)
 	downloadResults, err := artifactDownloader.DownloadAndSaveArtifacts(artifacts, targetDir)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to download artifacts: %w", err)

--- a/step/tracker.go
+++ b/step/tracker.go
@@ -19,7 +19,7 @@ func newTracker(envRepo env.Repository, logger log.Logger) tracker {
 		"app_slug":   envRepo.Get("BITRISE_APP_SLUG"),
 	}
 	return tracker{
-		tracker: analytics.NewDefaultTracker(logger, p),
+		tracker: analytics.NewDefaultTracker(logger, envRepo, p),
 	}
 }
 

--- a/vendor/github.com/bitrise-io/go-utils/v2/analytics/track.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/analytics/track.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
@@ -12,11 +13,13 @@ const poolSize = 10
 const bufferSize = 100
 const timeout = 30 * time.Second
 const asyncClientTimeout = 30 * time.Second
+const analyticsDisabledEnv = "ANALYTICS_DISABLED"
 
 // Tracker ...
 type Tracker interface {
 	Enqueue(eventName string, properties ...Properties)
 	Wait()
+	IsTracking() bool
 }
 
 type tracker struct {
@@ -27,8 +30,24 @@ type tracker struct {
 	waitTimeout time.Duration
 }
 
+type noopTracker struct{}
+
+// Enqueue ...
+func (t noopTracker) Enqueue(eventName string, properties ...Properties) {}
+
+// Wait ...
+func (t noopTracker) Wait() {}
+
+// IsTracking ...
+func (t noopTracker) IsTracking() bool {
+	return false
+}
+
 // NewDefaultTracker ...
-func NewDefaultTracker(logger log.Logger, properties ...Properties) Tracker {
+func NewDefaultTracker(logger log.Logger, envRepo env.Repository, properties ...Properties) Tracker {
+	if envRepo.Get(analyticsDisabledEnv) == "true" {
+		return noopTracker{}
+	}
 	return NewTracker(NewDefaultClient(logger, asyncClientTimeout), timeout, properties...)
 }
 
@@ -59,6 +78,11 @@ func (t tracker) Wait() {
 	case <-c:
 	case <-time.After(t.waitTimeout):
 	}
+}
+
+// IsTracking ...
+func (t tracker) IsTracking() bool {
+	return true
 }
 
 func (t tracker) init(size int) {

--- a/vendor/github.com/bitrise-io/go-utils/v2/command/errors.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/command/errors.go
@@ -16,15 +16,18 @@ type ExitStatusError struct {
 // NewExitStatusError ...
 func NewExitStatusError(printableCmdArgs string, exitErr *exec.ExitError, errorLines []string) error {
 	reasonMsg := fmt.Sprintf("command failed with exit status %d (%s)", exitErr.ExitCode(), printableCmdArgs)
-	if len(errorLines) == 0 {
-		return &ExitStatusError{
-			readableReason:  fmt.Errorf("%s: %w", reasonMsg, errors.New("check the command's output for details")),
-			originalExitErr: exitErr,
+
+	errorOutput := strings.Join(errorLines, "\n")
+	if len(errorOutput) == 0 {
+		if len(exitErr.Stderr) != 0 {
+			errorOutput = string(exitErr.Stderr)
+		} else {
+			errorOutput = "check the command's output for details"
 		}
 	}
 
 	return &ExitStatusError{
-		readableReason:  fmt.Errorf("%s: %w", reasonMsg, errors.New(strings.Join(errorLines, "\n"))),
+		readableReason:  fmt.Errorf("%s: %w", reasonMsg, errors.New(errorOutput)),
 		originalExitErr: exitErr,
 	}
 }

--- a/vendor/github.com/bitrise-io/go-utils/v2/env/env.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/env/env.go
@@ -1,6 +1,8 @@
 package env
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 )
@@ -22,11 +24,18 @@ func (l commandLocator) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
-// Repository ...
+// Repository abstracts read/write access to process environment variables.
+// Implementations should be safe to replace in tests (e.g. with an
+// in-memory fake) without touching the real process environment.
 type Repository interface {
+	// List returns the current environment as "KEY=VALUE" entries, like
+	// os.Environ().
 	List() []string
+	// Unset removes key from the environment.
 	Unset(key string) error
+	// Get returns the value of key, or "" when unset.
 	Get(key string) string
+	// Set assigns value to key.
 	Set(key, value string) error
 }
 
@@ -55,4 +64,116 @@ func (d repository) Unset(key string) error {
 // List ...
 func (d repository) List() []string {
 	return os.Environ()
+}
+
+// Getter is the minimal interface required to read an environment variable.
+// Callers should prefer defining their own local interface at the use site;
+// this type exists so the helpers in this package can stay small.
+type Getter interface {
+	Get(key string) string
+}
+
+// GetSetter is the minimal interface required to read and write environment
+// variables. Callers should prefer defining their own local interface at the
+// use site; this type exists so the helpers in this package can stay small.
+type GetSetter interface {
+	Get(key string) string
+	Set(key, value string) error
+}
+
+// GetOrDefault returns r.Get(key) when non-empty, else def.
+func GetOrDefault(r Getter, key, def string) string {
+	if v := r.Get(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// Required returns r.Get(key) or an error when it is unset or empty.
+func Required(r Getter, key string) (string, error) {
+	if v := r.Get(key); v != "" {
+		return v, nil
+	}
+	return "", fmt.Errorf("required environment variable (%s) not provided", key)
+}
+
+// FlagOrEnv returns *flag when it points to a non-empty string, else r.Get(key).
+// A nil pointer is treated as unset.
+func FlagOrEnv(r Getter, flag *string, key string) string {
+	if flag != nil && *flag != "" {
+		return *flag
+	}
+	return r.Get(key)
+}
+
+// Revokable sets key to value on r and returns a function that restores the
+// previous value when invoked.
+func Revokable(r GetSetter, key, value string) (func() error, error) {
+	orig := r.Get(key)
+	revoke := func() error { return r.Set(key, orig) }
+	return revoke, r.Set(key, value)
+}
+
+// RevokableMany sets every key in envs on r and returns a revoke function that
+// restores the previous values. If any Set fails, every key already written is
+// restored before returning on a best-effort basis; the returned error wraps
+// both the Set failure and any restore failures, and the returned revoke is
+// a no-op.
+func RevokableMany(r GetSetter, envs map[string]string) (func() error, error) {
+	originals := make(map[string]string, len(envs))
+	revoke := func() error {
+		var errs []error
+		for k, v := range originals {
+			if err := r.Set(k, v); err != nil {
+				errs = append(errs, fmt.Errorf("restore %q: %w", k, err))
+			}
+		}
+		return errors.Join(errs...)
+	}
+
+	for k, v := range envs {
+		originals[k] = r.Get(k)
+		if err := r.Set(k, v); err != nil {
+			if rerr := revoke(); rerr != nil {
+				return func() error { return nil }, fmt.Errorf("set %q: %w (restore failed: %w)", k, err, rerr)
+			}
+			return func() error { return nil }, fmt.Errorf("set %q: %w", k, err)
+		}
+	}
+	return revoke, nil
+}
+
+// Scoped sets key to value on r, invokes fn, then restores the previous value.
+// The restore runs even if fn panics, and even when the initial Set reports
+// an error (a GetSetter may leave state written and still return an error).
+func Scoped(r GetSetter, key, value string, fn func()) (err error) {
+	revoke, setErr := Revokable(r, key, value)
+	defer func() {
+		if rerr := revoke(); err == nil {
+			err = rerr
+		}
+	}()
+	if setErr != nil {
+		return setErr
+	}
+	fn()
+	return nil
+}
+
+// ScopedMany applies every entry in envs on r, invokes fn, then restores all
+// previous values. Restore runs even if fn panics. On setup failure
+// RevokableMany has already restored every key it touched and returns a
+// no-op revoke, so the deferred call is a safe cleanup either way.
+func ScopedMany(r GetSetter, envs map[string]string, fn func()) (err error) {
+	revoke, setErr := RevokableMany(r, envs)
+	defer func() {
+		if rerr := revoke(); err == nil {
+			err = rerr
+		}
+	}()
+	if setErr != nil {
+		return setErr
+	}
+	fn()
+	return nil
 }

--- a/vendor/github.com/bitrise-io/go-utils/v2/pathutil/path_filter.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/pathutil/path_filter.go
@@ -1,0 +1,156 @@
+package pathutil
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// FilterFunc decides whether an entry produced by an fs.FS walk should be
+// kept. The path is slash-separated and rooted at the fs root ("." for the
+// root itself). Returning fs.SkipDir as the error skips the current
+// directory's subtree.
+type FilterFunc func(pth string, d fs.DirEntry) (bool, error)
+
+// FilterFS walks fsys recursively and returns every path for which all
+// filters return true. Paths are slash-separated and relative to fsys.
+func FilterFS(fsys fs.FS, filters ...FilterFunc) ([]string, error) {
+	var filtered []string
+
+	err := fs.WalkDir(fsys, ".", func(pth string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		for _, filter := range filters {
+			matches, err := filter(pth, d)
+			if err != nil {
+				return err
+			}
+			if !matches {
+				return nil
+			}
+		}
+
+		filtered = append(filtered, pth)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return filtered, nil
+}
+
+// BaseFilter matches entries whose base name equals base (case-insensitive).
+// When allowed is false the match is inverted.
+func BaseFilter(base string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == strings.EqualFold(path.Base(pth), base), nil
+	}
+}
+
+// ExtensionFilter matches entries whose extension equals ext
+// (case-insensitive, leading dot included, e.g. ".txt").
+func ExtensionFilter(ext string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == strings.EqualFold(path.Ext(pth), ext), nil
+	}
+}
+
+// RegexpFilter matches entries whose path contains a match for pattern.
+// The pattern is compiled once when the filter is constructed.
+func RegexpFilter(pattern string, allowed bool) FilterFunc {
+	re := regexp.MustCompile(pattern)
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == (re.FindString(pth) != ""), nil
+	}
+}
+
+// ComponentFilter matches entries whose path contains component as one of
+// its slash-separated components.
+func ComponentFilter(component string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		found := slices.Contains(strings.Split(pth, "/"), component)
+		return allowed == found, nil
+	}
+}
+
+// ComponentWithExtensionFilter matches entries whose path has at least one
+// component with the given extension (case-insensitive, leading dot
+// included, e.g. ".xcodeproj").
+func ComponentWithExtensionFilter(ext string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		found := slices.ContainsFunc(strings.Split(pth, "/"), func(c string) bool {
+			return strings.EqualFold(path.Ext(c), ext)
+		})
+		return allowed == found, nil
+	}
+}
+
+// IsDirectoryFilter matches entries based on whether they are directories.
+func IsDirectoryFilter(allowed bool) FilterFunc {
+	return func(_ string, d fs.DirEntry) (bool, error) {
+		if d == nil {
+			return false, errors.New("no directory entry available")
+		}
+		return allowed == d.IsDir(), nil
+	}
+}
+
+// InDirectoryFilter matches entries whose direct parent directory equals dir.
+func InDirectoryFilter(dir string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == (path.Dir(pth) == dir), nil
+	}
+}
+
+// SkipDirectoryNameFilter keeps every non-directory entry. When it encounters
+// a directory whose base name matches dirName (case-insensitive) it returns
+// fs.SkipDir so the whole subtree is skipped.
+func SkipDirectoryNameFilter(dirName string) FilterFunc {
+	return func(pth string, d fs.DirEntry) (bool, error) {
+		if d == nil || !d.IsDir() {
+			return true, nil
+		}
+		if strings.EqualFold(path.Base(pth), dirName) {
+			return false, fs.SkipDir
+		}
+		return true, nil
+	}
+}
+
+// DirectoryContainsFileFilter matches directories that contain a regular
+// file named fileName. fsys is used to stat the candidate path.
+func DirectoryContainsFileFilter(fsys fs.FS, fileName string) FilterFunc {
+	return func(pth string, d fs.DirEntry) (bool, error) {
+		if d == nil || !d.IsDir() {
+			return false, nil
+		}
+		info, err := fs.Stat(fsys, path.Join(pth, fileName))
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return false, nil
+			}
+			return false, err
+		}
+		return !info.IsDir(), nil
+	}
+}
+
+// FileContainsFilter matches regular files whose contents include content.
+// Directories never match.
+func FileContainsFilter(fsys fs.FS, content string) FilterFunc {
+	return func(pth string, d fs.DirEntry) (bool, error) {
+		if d != nil && d.IsDir() {
+			return false, nil
+		}
+		data, err := fs.ReadFile(fsys, pth)
+		if err != nil {
+			return false, err
+		}
+		return strings.Contains(string(data), content), nil
+	}
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/pathutil/path_filter_compat.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/pathutil/path_filter_compat.go
@@ -1,0 +1,92 @@
+package pathutil
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// FilterPaths applies filters to an explicit list of OS paths and returns
+// the ones that pass every filter, preserving input order. Each path is
+// stat-ed opportunistically so filters that consult fs.DirEntry (e.g.
+// IsDirectoryFilter) work; paths that do not exist on disk are still fed
+// to the filters with a nil DirEntry, matching v1's purely lexical
+// behavior for path-only filters. Stat errors other than "not exist"
+// surface to the caller.
+//
+// This adapter preserves the v1 go-utils pathutil.FilterPaths signature so
+// callers can migrate by import-path rename only. Prefer FilterFS in new code.
+func FilterPaths(paths []string, filters ...FilterFunc) ([]string, error) {
+	var filtered []string
+	for _, pth := range paths {
+		var d fs.DirEntry
+		info, err := os.Lstat(pth)
+		switch {
+		case err == nil:
+			d = fs.FileInfoToDirEntry(info)
+		case errors.Is(err, fs.ErrNotExist):
+			// Leave d nil; path-only filters still work.
+		default:
+			return nil, err
+		}
+
+		keep, err := runFilters(filepath.ToSlash(pth), d, filters)
+		if err != nil {
+			return nil, err
+		}
+		if keep {
+			filtered = append(filtered, pth)
+		}
+	}
+	return filtered, nil
+}
+
+// ListEntries lists the immediate children of dir, applies filters, and
+// returns the matching entries as absolute paths. It is non-recursive.
+//
+// This adapter preserves the v1 go-utils pathutil.ListEntries signature so
+// callers can migrate by import-path rename only. Prefer FilterFS on an
+// fs.FS in new code.
+func ListEntries(dir string, filters ...FilterFunc) ([]string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []string
+	for _, entry := range entries {
+		pth := filepath.Join(absDir, entry.Name())
+		keep, err := runFilters(filepath.ToSlash(pth), entry, filters)
+		if err != nil {
+			return nil, err
+		}
+		if keep {
+			filtered = append(filtered, pth)
+		}
+	}
+	return filtered, nil
+}
+
+// runFilters evaluates filters in order. fs.SkipDir from a filter is
+// treated as "exclude this entry" rather than a walk directive, because the
+// compat adapters do not walk a tree.
+func runFilters(pth string, d fs.DirEntry, filters []FilterFunc) (bool, error) {
+	for _, filter := range filters {
+		matches, err := filter(pth, d)
+		if err != nil {
+			if errors.Is(err, fs.SkipDir) {
+				return false, nil
+			}
+			return false, err
+		}
+		if !matches {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/pathutil/sortable_path.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/pathutil/sortable_path.go
@@ -1,0 +1,111 @@
+package pathutil
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SortablePath pairs a path with its absolute form and component breakdown,
+// enabling sorts that compare entries by directory depth.
+type SortablePath struct {
+	Pth        string
+	AbsPth     string
+	Components []string
+}
+
+// NewSortablePath expands pth to its absolute form and splits it into
+// non-empty components suitable for depth-based sorting.
+func NewSortablePath(pth string) (SortablePath, error) {
+	absPth, err := pathModifier{}.AbsPath(pth)
+	if err != nil {
+		return SortablePath{}, err
+	}
+
+	var components []string
+	for _, c := range strings.Split(absPth, string(os.PathSeparator)) {
+		if c != "" {
+			components = append(components, c)
+		}
+	}
+
+	return SortablePath{
+		Pth:        pth,
+		AbsPth:     absPth,
+		Components: components,
+	}, nil
+}
+
+// BySortablePathComponents sorts SortablePath values by component depth
+// (shallowest first), breaking ties alphabetically on the base name and
+// falling back to the absolute and original paths to keep the order
+// deterministic when same-depth same-base entries exist.
+type BySortablePathComponents []SortablePath
+
+func (s BySortablePathComponents) Len() int      { return len(s) }
+func (s BySortablePathComponents) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s BySortablePathComponents) Less(i, j int) bool {
+	if len(s[i].Components) != len(s[j].Components) {
+		return len(s[i].Components) < len(s[j].Components)
+	}
+	baseI, baseJ := filepath.Base(s[i].AbsPth), filepath.Base(s[j].AbsPth)
+	if baseI != baseJ {
+		return baseI < baseJ
+	}
+	if s[i].AbsPth != s[j].AbsPth {
+		return s[i].AbsPth < s[j].AbsPth
+	}
+	return s[i].Pth < s[j].Pth
+}
+
+// SortPathsByComponents returns paths sorted by directory depth.
+func SortPathsByComponents(paths []string) ([]string, error) {
+	sortables := make([]SortablePath, 0, len(paths))
+	for _, p := range paths {
+		sp, err := NewSortablePath(p)
+		if err != nil {
+			return nil, err
+		}
+		sortables = append(sortables, sp)
+	}
+
+	sort.Sort(BySortablePathComponents(sortables))
+
+	sorted := make([]string, 0, len(sortables))
+	for _, sp := range sortables {
+		sorted = append(sorted, sp.Pth)
+	}
+	return sorted, nil
+}
+
+// ListPathInDirSortedByComponents walks searchDir recursively and returns
+// every path found, sorted by directory depth. If relPath is true the paths
+// are returned relative to searchDir.
+func ListPathInDirSortedByComponents(searchDir string, relPath bool) ([]string, error) {
+	absDir, err := filepath.Abs(searchDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	err = filepath.WalkDir(absDir, func(p string, _ fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if relPath {
+			rel, err := filepath.Rel(absDir, p)
+			if err != nil {
+				return err
+			}
+			p = rel
+		}
+		paths = append(paths, p)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return SortPathsByComponents(paths)
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/ziputil/os_proxy.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/ziputil/os_proxy.go
@@ -1,0 +1,36 @@
+package ziputil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// OsProxy defines the subset of OS operations used by ZipManager.
+type OsProxy interface {
+	Lstat(name string) (os.FileInfo, error)
+	Readlink(name string) (string, error)
+	Open(name string) (*os.File, error)
+	Create(name string) (*os.File, error)
+	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+	Remove(name string) error
+	Rename(oldpath, newpath string) error
+	MkdirAll(path string, perm os.FileMode) error
+	Symlink(oldname, newname string) error
+	EvalSymlinks(path string) (string, error)
+}
+
+// RealOS is the default implementation that delegates to the real os package.
+type RealOS struct{}
+
+func (RealOS) Lstat(name string) (os.FileInfo, error)            { return os.Lstat(name) }                          //nolint:revive
+func (RealOS) Readlink(name string) (string, error)              { return os.Readlink(name) }                       //nolint:revive
+func (RealOS) Open(name string) (*os.File, error)                { return os.Open(name) }                           //nolint:revive
+func (RealOS) Create(name string) (*os.File, error)              { return os.Create(name) }                         //nolint:revive
+func (RealOS) MkdirAll(path string, perm os.FileMode) error      { return os.MkdirAll(path, perm) }                 //nolint:revive
+func (RealOS) Symlink(oldname, newname string) error             { return os.Symlink(oldname, newname) }            //nolint:revive
+func (RealOS) EvalSymlinks(path string) (string, error)          { return filepath.EvalSymlinks(path) }             //nolint:revive
+func (RealOS) Remove(name string) error                          { return os.Remove(name) }                         //nolint:revive
+func (RealOS) Rename(oldpath, newpath string) error              { return os.Rename(oldpath, newpath) }             //nolint:revive
+func (RealOS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {                                 //nolint:revive
+	return os.OpenFile(name, flag, perm)
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/ziputil/ziputil.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/ziputil/ziputil.go
@@ -1,0 +1,355 @@
+package ziputil
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/pathutil"
+)
+
+// ZipManager provides zip and unzip operations using Go stdlib.
+type ZipManager struct {
+	pathChecker pathutil.PathChecker
+	osProxy     OsProxy
+}
+
+// NewZipManager creates a ZipManager backed by the real OS.
+func NewZipManager(pathChecker pathutil.PathChecker) *ZipManager {
+	return &ZipManager{pathChecker: pathChecker, osProxy: RealOS{}}
+}
+
+// ZipDir zips sourceDirPth into destinationZipPth.
+// isContentOnly=false: archive contains the directory under its own basename (e.g. "mydir/file.txt").
+// isContentOnly=true: archive contains the directory's contents directly (e.g. "file.txt").
+// Directory modification times are preserved. Symlinks are stored as symlinks (not followed).
+func (z *ZipManager) ZipDir(sourceDirPth, destinationZipPth string, isContentOnly bool) error {
+	if exist, err := z.pathChecker.IsDirExists(sourceDirPth); err != nil {
+		return err
+	} else if !exist {
+		return fmt.Errorf("directory (%s) does not exist", sourceDirPth)
+	}
+
+	baseDir := filepath.Dir(sourceDirPth)
+	if isContentOnly {
+		baseDir = sourceDirPth
+	}
+
+	return z.createZipFromDir(destinationZipPth, sourceDirPth, baseDir)
+}
+
+// ZipDirs zips multiple directories into a single archive, each under its own basename.
+// When two entries in sourceDirPths share the same basename (e.g. "/a/shared" and "/b/shared"),
+// their contents are merged: files unique to either directory are preserved, and conflicting
+// files (same relative path) resolve in favour of the last directory in the list.
+func (z *ZipManager) ZipDirs(sourceDirPths []string, destinationZipPth string) error {
+	for _, path := range sourceDirPths {
+		if exist, err := z.pathChecker.IsDirExists(path); err != nil {
+			return err
+		} else if !exist {
+			return fmt.Errorf("directory (%s) does not exist", path)
+		}
+	}
+
+	return z.createZipFile(destinationZipPth, func(zw *zip.Writer) error {
+		for _, sourceDirPth := range sourceDirPths {
+			if err := z.addDirToZip(zw, sourceDirPth, filepath.Dir(sourceDirPth)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// ZipFile zips a single file into destinationZipPth.
+func (z *ZipManager) ZipFile(sourceFilePth, destinationZipPth string) error {
+	return z.ZipFiles([]string{sourceFilePth}, destinationZipPth)
+}
+
+// ZipFiles zips multiple files into destinationZipPth without preserving directory structure.
+// Each file is stored under its base name only. Symlinks are stored as symlinks (not followed).
+// If two source files share the same base name, an error is returned before the destination
+// file is created.
+func (z *ZipManager) ZipFiles(sourceFilePths []string, destinationZipPth string) error {
+	seen := make(map[string]bool)
+	for _, path := range sourceFilePths {
+		if exist, err := z.pathChecker.IsPathExists(path); err != nil {
+			return err
+		} else if !exist {
+			return fmt.Errorf("file (%s) does not exist", path)
+		}
+		baseName := filepath.Base(path)
+		if seen[baseName] {
+			return fmt.Errorf("duplicate file name %q: files with the same base name cannot be zipped together", baseName)
+		}
+		seen[baseName] = true
+	}
+
+	return z.createZipFile(destinationZipPth, func(zw *zip.Writer) error {
+		for _, filePath := range sourceFilePths {
+			if err := z.addFileToZip(zw, filePath, filepath.Base(filePath)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// UnZip extracts the zip archive at zipPth into intoDir, restoring permissions and symlinks.
+// Entries with path-traversal components (e.g. "../../escape") are rejected and an error is
+// returned immediately; no further entries are extracted after a traversal is detected.
+// Rejection is by substring: any entry whose name contains ".." anywhere is refused, including
+// otherwise-legitimate names like "foo..bar". This is broader than strict path-component
+// traversal, but is required for the repo's static analysis to recognise the sanitizer.
+func (z *ZipManager) UnZip(zipPth, intoDir string) error {
+	r, err := zip.OpenReader(zipPth)
+	if err != nil {
+		return err
+	}
+	defer r.Close() //nolint:errcheck
+
+	cleanDest := filepath.Clean(intoDir)
+	// Ensure intoDir exists so EvalSymlinks can resolve it before processing any entry.
+	if err := z.osProxy.MkdirAll(cleanDest, 0755); err != nil {
+		return err
+	}
+	// Resolve once per call; EvalSymlinks is called per-entry otherwise (O(n) syscalls).
+	// Both cleanDest and realDest are passed to extractEntry to avoid re-computing them.
+	realDest, err := z.osProxy.EvalSymlinks(cleanDest)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range r.File {
+		// CodeQL's go/zipslip recognises strings.Contains(f.Name, "..") as the canonical
+		// taint sanitizer at the loop source. Must be standalone here — a compound && check
+		// leaves a reachable path where strings.Contains is true but execution continues,
+		// which CodeQL flags as unsanitized. Do not extract into a helper.
+		// Tradeoff: any entry whose name contains ".." as a substring is rejected, including
+		// names like "module..framework". No such names appear in iOS/Xcode artifact formats.
+		if strings.Contains(f.Name, "..") {
+			return fmt.Errorf("illegal path in zip entry: %s", f.Name)
+		}
+		if err := z.extractEntry(f, cleanDest, realDest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (z *ZipManager) createZipFromDir(destinationZipPth, sourceDirPth, baseDir string) error {
+	return z.createZipFile(destinationZipPth, func(zw *zip.Writer) error {
+		return z.addDirToZip(zw, sourceDirPth, baseDir)
+	})
+}
+
+// createZipFile builds a zip archive at destinationZipPth, delegating entry creation to
+// addEntries. It writes to a temporary file in the destination directory and renames it over
+// destinationZipPth only after writing succeeds, so a pre-existing destination is left
+// untouched on failure. This mirrors v1, where `zip -T` validated a temporary archive before
+// promoting it to the destination.
+func (z *ZipManager) createZipFile(destinationZipPth string, addEntries func(zw *zip.Writer) error) (retErr error) {
+	tmpPath := destinationZipPth + ".tmp"
+
+	dest, err := z.osProxy.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			z.osProxy.Remove(tmpPath) //nolint:errcheck
+		}
+	}()
+
+	zw := zip.NewWriter(dest)
+	if err := addEntries(zw); err != nil {
+		dest.Close() //nolint:errcheck
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		dest.Close() //nolint:errcheck
+		return err
+	}
+	if err := dest.Close(); err != nil {
+		return err
+	}
+
+	return z.osProxy.Rename(tmpPath, destinationZipPth)
+}
+
+func (z *ZipManager) addDirToZip(zw *zip.Writer, sourceDirPth, baseDir string) error {
+	return filepath.WalkDir(sourceDirPth, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(baseDir, path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+
+		if d.Type()&fs.ModeSymlink != 0 {
+			return z.addSymlinkToZip(zw, path, relPath)
+		}
+
+		if d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			hdr := &zip.FileHeader{
+				Name:     relPath + "/",
+				Method:   zip.Store,
+				Modified: info.ModTime(),
+			}
+			hdr.SetMode(info.Mode())
+			_, err = zw.CreateHeader(hdr)
+			return err
+		}
+
+		return z.addFileToZip(zw, path, relPath)
+	})
+}
+
+func (z *ZipManager) addSymlinkToZip(zw *zip.Writer, path, name string) error {
+	target, err := z.osProxy.Readlink(path)
+	if err != nil {
+		return err
+	}
+
+	hdr := &zip.FileHeader{
+		Name:   name,
+		Method: zip.Store,
+	}
+	hdr.SetMode(os.ModeSymlink | 0777)
+
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte(target))
+	return err
+}
+
+func (z *ZipManager) addFileToZip(zw *zip.Writer, path, name string) error {
+	info, err := z.osProxy.Lstat(path)
+	if err != nil {
+		return err
+	}
+
+	// If the path is a symlink, store it as a symlink rather than following it.
+	if info.Mode()&os.ModeSymlink != 0 {
+		return z.addSymlinkToZip(zw, path, name)
+	}
+
+	hdr, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	hdr.Name = name
+	hdr.Method = zip.Deflate
+
+	src, err := z.osProxy.Open(path)
+	if err != nil {
+		return err
+	}
+	defer src.Close() //nolint:errcheck
+
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, src)
+	return err
+}
+
+// extractEntry extracts a single zip entry into cleanDest.
+// cleanDest must be filepath.Clean(intoDir); realDest must be EvalSymlinks(cleanDest).
+// Both are pre-computed by UnZip to avoid redundant syscalls across entries.
+func (z *ZipManager) extractEntry(f *zip.File, cleanDest, realDest string) error {
+	// Duplicates UnZip's strings.Contains pre-filter on purpose: it keeps the ".." sanitizer in
+	// the same function as the file-system sinks below, which is what CodeQL's go/zipslip query
+	// needs to treat them as sanitized. It is also genuine defense-in-depth. Do not remove it
+	// just because UnZip already rejects these names before calling extractEntry.
+	if strings.Contains(f.Name, "..") {
+		return fmt.Errorf("illegal path in zip entry: %s", f.Name)
+	}
+	sep := string(os.PathSeparator)
+	destPath := filepath.Clean(filepath.Join(cleanDest, f.Name))
+	if destPath != cleanDest && !strings.HasPrefix(destPath, cleanDest+sep) {
+		return fmt.Errorf("illegal path in zip entry: %s", f.Name)
+	}
+
+	if f.Mode()&os.ModeSymlink != 0 {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer rc.Close() //nolint:errcheck
+
+		target, err := io.ReadAll(rc)
+		if err != nil {
+			return err
+		}
+		targetStr := string(target)
+		if filepath.IsAbs(targetStr) {
+			return fmt.Errorf("symlink target %q is absolute", targetStr)
+		}
+		resolvedTarget := filepath.Clean(filepath.Join(filepath.Dir(destPath), targetStr))
+		if resolvedTarget != cleanDest && !strings.HasPrefix(resolvedTarget, cleanDest+sep) {
+			return fmt.Errorf("symlink target %q escapes extraction directory", targetStr)
+		}
+		if err := z.osProxy.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return err
+		}
+		// Resolve pre-existing symlinks in the parent path (go/unsafe-unzip-symlink): a
+		// previously extracted symlink could make the parent resolve outside cleanDest even
+		// though the syntactic path appears inside it.
+		realParent, err := z.osProxy.EvalSymlinks(filepath.Dir(destPath))
+		if err != nil {
+			return err
+		}
+		if realParent != realDest && !strings.HasPrefix(realParent, realDest+sep) {
+			return fmt.Errorf("symlink parent %q escapes extraction directory", filepath.Dir(destPath))
+		}
+		return z.osProxy.Symlink(targetStr, destPath)
+	}
+
+	if f.FileInfo().IsDir() {
+		return z.osProxy.MkdirAll(destPath, f.Mode().Perm())
+	}
+
+	if err := z.osProxy.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
+	// Same chained-symlink check for regular files.
+	realParent, err := z.osProxy.EvalSymlinks(filepath.Dir(destPath))
+	if err != nil {
+		return err
+	}
+	if realParent != realDest && !strings.HasPrefix(realParent, realDest+sep) {
+		return fmt.Errorf("file parent %q escapes extraction directory", filepath.Dir(destPath))
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close() //nolint:errcheck
+
+	dest, err := z.osProxy.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer dest.Close() //nolint:errcheck
+
+	_, err = io.Copy(dest, rc)
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,8 +12,8 @@ github.com/bitrise-io/go-utils/log
 github.com/bitrise-io/go-utils/pathutil
 github.com/bitrise-io/go-utils/retry
 github.com/bitrise-io/go-utils/ziputil
-# github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23
-## explicit; go 1.17
+# github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36.0.20260612135825-fa80291d0871
+## explicit; go 1.21
 github.com/bitrise-io/go-utils/v2/analytics
 github.com/bitrise-io/go-utils/v2/command
 github.com/bitrise-io/go-utils/v2/env
@@ -21,6 +21,7 @@ github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/log/colorstring
 github.com/bitrise-io/go-utils/v2/pathutil
 github.com/bitrise-io/go-utils/v2/retryhttp
+github.com/bitrise-io/go-utils/v2/ziputil
 # github.com/bitrise-io/got v0.0.0-20250613112826-9af8c0e04db5
 ## explicit; go 1.18
 github.com/bitrise-io/got


### PR DESCRIPTION
## Summary
Adds the new pure-Go `go-utils/v2/ziputil.UnZip` extractor as an opt-in alternative to the legacy `unzip` CLI for directory artifacts, gated behind the `BITRISE_STEP_PULL_ARTIFACT_USE_ZIP_V2` env var.

- Flag **off** (default): unchanged behavior — extract via the `unzip` CLI.
- Flag **on** (`=true`): extract via `ziputil.NewZipManager(pathutil.NewPathChecker()).UnZip(...)` (pure Go, zip-slip / symlink-escape protections, no system `unzip` dependency).
- Tar path is untouched (ziputil has no tar support).

## Changes
- `downloader/artifact_downloader.go`: `UseZipV2` field + constructor param; branch in `extractZipArchive`.
- `step/step.go`: read the env flag and thread it into the downloader.
- `step/tracker.go`: adjust `analytics.NewDefaultTracker` call for the updated signature in the bumped `go-utils/v2`.
- `go.mod`/`go.sum` + vendor: bump `go-utils/v2` to the `ziputil-v2` branch.
- Tests: existing `unzip`-CLI path retained; new `Test_DownloadAndSaveZipDirectoryArtifacts_ZipV2` verifies pure-Go extraction and that the CLI is never invoked.


🤖 Generated with [Claude Code](https://claude.com/claude-code)